### PR TITLE
Deixa o menu branco depois do scroll

### DIFF
--- a/src/assets/scss/custom/vendor/_headroom.scss
+++ b/src/assets/scss/custom/vendor/_headroom.scss
@@ -16,6 +16,6 @@
 .headroom--not-top {
 	padding-top: .5rem;
 	padding-bottom: .5rem;
-    background-color: #e6e6e6 ("default") !important;
+    background-color: #fff !important;
     box-shadow: 0 1px 10px rgba(130, 130, 134, 0.1);
 }


### PR DESCRIPTION
<img width="1493" alt="Captura de Tela 2020-03-08 às 23 27 05" src="https://user-images.githubusercontent.com/4144597/76177920-578af500-6194-11ea-9009-35849695d4e8.png">
